### PR TITLE
Multitile Airlocks fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -19,7 +19,7 @@ var/list/airlock_overlays = list()
 /obj/machinery/door/airlock
 	name = "airlock"
 	icon = 'icons/obj/doors/station/door.dmi'
-	icon_state = "preview"
+	icon_state = "closed"
 	power_channel = ENVIRON
 	interact_offline = FALSE
 

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -28,6 +28,7 @@
 	. = ..()
 	SetBounds()
 
+/*
 /obj/machinery/door/airlock/multi_tile/proc/SetBounds()
 	if(dir in list(NORTH, SOUTH))
 		bound_width = width * world.icon_size
@@ -35,7 +36,7 @@
 	else
 		bound_width = world.icon_size
 		bound_height = width * world.icon_size
-
+*/
 
 /obj/machinery/door/airlock/multi_tile/on_update_icon(state=0, override=0)
 	..()
@@ -71,9 +72,12 @@
 				for(var/b_type in blend_objects)
 					if( istype(O, b_type))
 						success = 1
-
-					if(success)
 						break
+
+				if(istype(O, /obj/effect/wallframe_spawn))
+					success = 1
+					break
+
 				if(success)
 					break
 

--- a/code_ark/code/game/machinery/doors/multi_tile.dm
+++ b/code_ark/code/game/machinery/doors/multi_tile.dm
@@ -1,4 +1,21 @@
-/obj/machinery/door/airlock/multi_tile/SetBounds()
+/obj/machinery/door/airlock/multi_tile
+	var/multi_filler = list()
+
+/obj/machinery/door/airlock/multi_tile/New()
+	..()
+	SetBounds()
+
+/obj/machinery/door/airlock/multi_tile/Move()
+	. = ..()
+	SetBounds()
+
+/obj/machinery/door/airlock/multi_tile/Destroy()
+	. = ..()
+	set_opacity(0)
+	update_filler_turfs()
+	density = FALSE
+
+/obj/machinery/door/airlock/multi_tile/proc/SetBounds()
 	if(!(width > 1)) return //Bubblewrap
 
 	for(var/i = 1, i < width, i++)
@@ -16,27 +33,49 @@
 		bound_width = world.icon_size
 		bound_height = width * world.icon_size
 
-//We have to find these again since these doors are used on shuttles a lot so the turfs changes
-/obj/machinery/door/airlock/multi_tile/proc/update_filler_turfs()
-	for(var/i = 1, i < width, i++)
-		if(dir in list(NORTH, SOUTH))
-			var/turf/T = locate(x + i, y, z)
-			if(T) T.set_opacity(opacity)
-		else if(dir in list(EAST, WEST))
-			var/turf/T = locate(x, y + i, z)
-			if(T) T.set_opacity(opacity)
+/obj/machinery/door/airlock/multi_tile/proc/handle_multidoor()
+	if(!(width > 1)) return //Bubblewrap
 
+	update_filler_turfs()
+	if(dir in list(NORTH, SOUTH))
+		bound_height = world.icon_size * width
+		bound_width = world.icon_size
+	else if(dir in list(EAST, WEST))
+		bound_width = world.icon_size * width
+		bound_height = world.icon_size
+
+//We have to find these again since these doors are used on shuttles a lot so the turfs changes
+/obj/machinery/door/airlock/multi_tile/proc/update_filler_turfs(var/closing = FALSE)
+	for(var/turf/T in multi_filler)
+		T.set_opacity(FALSE)
+
+	multi_filler = list()
+	for(var/turf/T in get_filler_turfs())
+		T.set_opacity(closing)
+		multi_filler += list(T)
 
 /obj/machinery/door/airlock/multi_tile/proc/get_filler_turfs()
-	var/list/filler_turfs = list()
+	. = list()
 	for(var/i = 1, i < width, i++)
 		if(dir in list(NORTH, SOUTH))
 			var/turf/T = locate(x + i, y, z)
-			if(T) filler_turfs += T
+			if(T)
+				. += list(T)
 		else if(dir in list(EAST, WEST))
 			var/turf/T = locate(x, y + i, z)
-			if(T) filler_turfs += T
-	return filler_turfs
+			if(T)
+				. += list(T)
+
+
+/obj/machinery/door/airlock/multi_tile/open()
+	. = ..()
+	if(!glass)
+		update_filler_turfs()
+
+/obj/machinery/door/airlock/multi_tile/close()
+	. = ..()
+	if(!glass)
+		update_filler_turfs(TRUE)
 
 /* /obj/machinery/door/airlock/multi_tile/deconstruct()
 	. = ..()
@@ -57,14 +96,6 @@
 		else if(dir in list(EAST, WEST))
 			var/turf/T = locate(x, y + i, z)
 			if(T) T.set_opacity(0) */ // WE NEEDA FIX THIS SHIT SOMEHOW
-
-/obj/machinery/door/airlock/multi_tile/open()
-	. = ..()
-	update_filler_turfs()
-
-/obj/machinery/door/airlock/multi_tile/close()
-	. = ..()
-	update_filler_turfs()
 
 /obj/machinery/door/airlock/multi_tile/glass
 	opacity = 0


### PR DESCRIPTION
1. Пофиксил проблему с задаванием направления двойным дверям при маппинге.
2. Пофиксил проблему со странными хитбоксами, возникающую у вертикальных мультитайловых дверей, если у них на соседних тайлах сверху и снизу не стояла хотя бы одна стена.
3. Пофиксил проблему с прозрачным тайлом у закрытых мультитайловых не стеклянных дверей.