### PR TITLE
Hotel fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3187,6 +3187,8 @@
 #include "code\unit_tests\virtual_mob_tests.dm"
 #include "code\unit_tests\zas_tests.dm"
 #include "code\unit_tests\~helpers.dm"
+#include "code_ark\code\__defines\hotel.dm"
+#include "code_ark\code\controllers\subsystems\hotel.dm"
 #include "code_ark\code\datums\reputation.dm"
 #include "code_ark\code\datums\audio\_tracks.dm"
 #include "code_ark\code\datums\extensions\underwear\undershirt.dm"

--- a/code_ark/code/__defines/hotel.dm
+++ b/code_ark/code/__defines/hotel.dm
@@ -1,0 +1,12 @@
+//Hotel rooms defines
+
+#define ROOM_STATUS_BROKEN					0	//for inoperable rooms
+#define ROOM_STATUS_AVAILABLE				1	//for available rooms
+#define ROOM_STATUS_RESERVATION_IN_PROGRESS	2	//to prevent simultaneous reservation of the same room
+#define ROOM_STATUS_OCCUPIED				3	//for occupied rooms
+#define ROOM_STATUS_BLOCKED					4	//for blocked rooms. Requires manual unblocking by  hotel staff
+
+#define ROOM_REQUEST_NONE			0		//default
+#define ROOM_REQUEST_NOT_DISTURB	1		//do not disturb
+#define ROOM_REQUEST_MAKE_UP		2		//clean the room
+#define ROOM_REQUEST_TURNOVER		3		//room turnover (set automatically at the end of the reservation)

--- a/code_ark/code/controllers/subsystems/hotel.dm
+++ b/code_ark/code/controllers/subsystems/hotel.dm
@@ -1,0 +1,29 @@
+SUBSYSTEM_DEF(hotel)
+	name = "Hotel"
+	wait = 1 MINUTE
+	priority = SS_PRIORITY_DEFAULT
+	init_order = SS_INIT_MISC_LATE				//Low order for initialization
+	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME
+
+
+//path for hotel systems: code_ark/code/modules/hotel
+
+
+/datum/controller/subsystem/hotel/Initialize()
+	setup_hotel_rooms()
+	. = ..()
+
+/datum/controller/subsystem/hotel/fire()
+	check_hotel_rooms_reservation_time()
+
+/datum/controller/subsystem/hotel/proc/setup_hotel_rooms()
+	if (!LAZYLEN(GLOB.hotel_rooms))
+		var/rooms_list = GLOB.hotel_room_presets
+		for(var/room_number in rooms_list)
+			var/hotel_room_preset_path = rooms_list[room_number]
+			var/datum/hotel_room/HR = new(room_number, hotel_room_preset_path)
+			GLOB.hotel_rooms += HR
+
+/datum/controller/subsystem/hotel/proc/check_hotel_rooms_reservation_time()
+	for(var/datum/hotel_room/HL in GLOB.hotel_rooms)
+		HL.reservation_time_check()

--- a/code_ark/code/modules/hotel/hotel_software.dm
+++ b/code_ark/code/modules/hotel/hotel_software.dm
@@ -40,7 +40,7 @@
 	for(var/datum/hotel_room/R in GLOB.hotel_rooms)
 
 		if (R == selected_room)
-			if (R.room_status == 0)
+			if (R.room_status == ROOM_STATUS_BROKEN)
 				give_error()
 			else
 				hotel_selected_room = list(
@@ -214,10 +214,10 @@
 	if (href_list["room_reserve"])
 		if(locate_n_check_terminal() != 3 || !selected_room)// Room shall not be reserved unless there's a properly functioning terminal
 			return TOPIC_REFRESH
-		if(selected_room.room_status != 1)
+		if(selected_room.room_status != ROOM_STATUS_AVAILABLE)
 			return TOPIC_REFRESH
 
-		selected_room.room_status = 2
+		selected_room.room_status = ROOM_STATUS_RESERVATION_IN_PROGRESS
 		reservation_duration = 1
 		program_mode = 4
 		reservation_status = 0
@@ -234,7 +234,7 @@
 	if (href_list["room_cancel"])
 		if(!selected_room)
 			return TOPIC_REFRESH
-		if(selected_room.room_status == 3)
+		if(selected_room.room_status == ROOM_STATUS_OCCUPIED)
 			if(alert("This will immediately cancel the reservation, invalidating keycards of the guests. Are you sure?",,"Yes","No")=="No")
 				return
 		selected_room.clear_reservation(just_reset = text2num(href_list["room_cancel"]) == 2 ? 1 : 0)

--- a/code_ark/code/modules/hotel/room_controllers.dm
+++ b/code_ark/code/modules/hotel/room_controllers.dm
@@ -55,7 +55,8 @@ GLOBAL_LIST_EMPTY(hotel_room_controllers)
 
 /obj/machinery/hotel_room_controller/interface_interact(var/mob/user)
 	flick_screen("room_controller_screensaver")
-	ui_interact(user)
+	to_chat(user, "<span class='warning'>\The [src] is temporarily unavailable. Software update pending. For requests please contact hotel staff directly.</span>")
+	//ui_interact(user)
 	return TRUE
 
 /obj/machinery/hotel_room_controller/CanUseTopic(user, state)
@@ -65,6 +66,8 @@ GLOBAL_LIST_EMPTY(hotel_room_controllers)
 	return ..()
 
 /obj/machinery/hotel_room_controller/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+
+	/*
 	var/list/data = new
 
 	data["room_status"] = hotel_room.room_status
@@ -78,3 +81,4 @@ GLOBAL_LIST_EMPTY(hotel_room_controllers)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
+	*/

--- a/code_ark/code/modules/hotel/room_keys.dm
+++ b/code_ark/code/modules/hotel/room_keys.dm
@@ -33,7 +33,7 @@
 	to_chat(usr, SPAN_NOTICE("This keycard was issued to [registered_name]."))
 	to_chat(usr, SPAN_NOTICE("The room is [room_number]."))
 	if (expired)
-		to_chat(user, SPAN_NOTICE("This keycard indicates that the room's reservation period has ended. Better to return it to hotel staff."))
+		to_chat(usr, SPAN_NOTICE("This keycard indicates that the room's reservation period has ended. Better to return it to hotel staff."))
 		//Must be restored once hotel controllers get proper interface and functions
 		//to_chat(usr, SPAN_NOTICE("This keycard appears to have either expired or been invalidated."))
 

--- a/code_ark/code/modules/hotel/room_keys.dm
+++ b/code_ark/code/modules/hotel/room_keys.dm
@@ -25,13 +25,17 @@
 	. = ..()
 	to_chat(user, SPAN_NOTICE("The room is [room_number]."))
 	if (expired)
-		to_chat(user, SPAN_NOTICE("This keycard appears to have either expired or been invalidated."))
+		to_chat(user, SPAN_NOTICE("This keycard indicates that the room's reservation period has ended. Better to return it to hotel staff."))
+		//Must be restored once hotel controllers get proper interface and functions
+		//to_chat(user, SPAN_NOTICE("This keycard appears to have either expired or been invalidated."))
 
 /obj/item/card/id/hotel_key/read()
 	to_chat(usr, SPAN_NOTICE("This keycard was issued to [registered_name]."))
 	to_chat(usr, SPAN_NOTICE("The room is [room_number]."))
 	if (expired)
-		to_chat(usr, SPAN_NOTICE("This keycard appears to have either expired or been invalidated."))
+		to_chat(user, SPAN_NOTICE("This keycard indicates that the room's reservation period has ended. Better to return it to hotel staff."))
+		//Must be restored once hotel controllers get proper interface and functions
+		//to_chat(usr, SPAN_NOTICE("This keycard appears to have either expired or been invalidated."))
 
 /obj/item/card/id/hotel_key/attack_self(mob/user as mob)
 	user.visible_message("\The [user] shows you: [icon2html(src, viewers(get_turf(src)))] [src.name]. The room on the card: [src.room_number]",\
@@ -44,6 +48,6 @@
 	return temp_access
 
 /obj/item/card/id/hotel_key/proc/expire()
-	temp_access = initial(temp_access)
+	//temp_access = initial(temp_access) temporarily disabled until room controller gets proper interface and fucntions
 	icon_state = "vertex_keycard"
 	expired = TRUE

--- a/code_ark/code/modules/hotel/room_signs.dm
+++ b/code_ark/code/modules/hotel/room_signs.dm
@@ -27,13 +27,13 @@ GLOBAL_LIST_EMPTY(hotel_room_signs)
 /obj/machinery/hotel_room_sign/on_update_icon()
 	overlays.Cut()
 	var/image/I = image(icon, icon_state)
-	if((stat & NOPOWER) || !hotel_room || hotel_room.room_status == 0)
+	if((stat & NOPOWER) || !hotel_room || hotel_room.room_status == ROOM_STATUS_BROKEN)
 		I.color = "#999999"
 		set_light(0)
 		overlays += I
 		return
 	else
-		I.color = (hotel_room.room_requests > 1) ? "#f5ea84" : hotel_room.room_requests == 1 ? "#f58484" : "#ffffff"
+		I.color = (hotel_room.room_requests > 1) ? "#f5ea84" : hotel_room.room_requests == ROOM_REQUEST_NOT_DISTURB ? "#f58484" : "#ffffff"
 	set_light(0.3, 0.1, 1, 2, I.color)
 	I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	I.layer = ABOVE_LIGHTING_LAYER


### PR DESCRIPTION
1. Replaced room reservation timers with basic hotel subsystem that fires up every minute to check reservation end time against current time for each occupied room. Same subsystem also initializes rooms themselves instead of a reservation computer now.
2. Replaced statuses numbers with defines for readability.
3. Fixed bug with reservation terminal when attempting to return to main menu after finishing reservation, which resulted in canceling last reservation.
4. Temporarily disabled automated removal of room access for hotel keycards and made them disaposable via reservation terminal. Requires hotel staff access to perform. Expired keycards description says they are supposed to be returned to staff.
5. Added notification to user when attempting to interact with room controller, saying to contact hotel staff directly. Should be removed once room controllers get proper interface and functionality.