### PR TITLE
Minor Map Fixes & Updates 2nd Try

### DIFF
--- a/maps/liberty/liberty2_level1.dmm
+++ b/maps/liberty/liberty2_level1.dmm
@@ -17734,12 +17734,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberty/hotel/hallway/staff)
 "aHx" = (
-/obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/closet,
+/obj/item/storage/box,
+/obj/item/storage/box,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aHy" = (
-/obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/light/spot{
 	dir = 1
@@ -17748,30 +17749,33 @@
 /area/liberty/hotel/staff_room)
 "aHz" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/hotel/staff_room)
-"aHA" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/bed/chair/padded/green{
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/box,
 /turf/simulated/floor/tiled/dark,
+/area/liberty/hotel/staff_room)
+"aHA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aHB" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aHC" = (
-/obj/structure/bed/chair/padded/green{
-	dir = 8
-	},
 /obj/machinery/light/spot{
 	dir = 1
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aHD" = (
@@ -17779,6 +17783,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aHE" = (
@@ -18462,30 +18467,27 @@
 /area/liberty/hotel/hallway/staff)
 "aJa" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/structure/closet,
+/obj/structure/window/reinforced,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aJb" = (
 /obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/door/window/southleft,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aJc" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aJd" = (
-/obj/structure/bed/chair/padded/green{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/pen,
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aJe" = (
@@ -19457,24 +19459,16 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberty/hotel/staff_room)
 "aKL" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aKM" = (
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -19501,16 +19495,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aKO" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/effect/floor_decal/spline/fancy/black{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -19522,7 +19515,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aKP" = (
 /obj/structure/cable/green{
@@ -19555,6 +19553,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aKS" = (
@@ -20248,28 +20247,40 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/hallway/staff)
 "aMi" = (
-/obj/structure/bed/chair/pew,
 /obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/item/storage/box,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aMj" = (
-/obj/structure/bed/chair/pew/left,
 /obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/door/window/northleft,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aMk" = (
-/obj/structure/bed/chair/pew,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/liberty/hotel/staff_room)
-"aMl" = (
-/obj/structure/bed/chair/pew/left,
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/item/storage/box,
+/obj/item/storage/box,
 /turf/simulated/floor/tiled/dark,
+/area/liberty/hotel/staff_room)
+"aMl" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aMm" = (
 /obj/structure/cable/green{
@@ -21066,7 +21077,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/staff_room)
 "aNK" = (
-/obj/structure/closet,
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/light/spot,
 /turf/simulated/floor/tiled/dark,
@@ -21074,18 +21084,20 @@
 "aNL" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/hotel/staff_room)
-"aNM" = (
-/obj/structure/closet,
-/obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/box,
+/obj/item/storage/box,
 /turf/simulated/floor/tiled/dark,
+/area/liberty/hotel/staff_room)
+"aNM" = (
+/obj/structure/table/standard,
+/obj/item/pen,
+/turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aNN" = (
 /obj/structure/cable/green{
@@ -22067,6 +22079,9 @@
 /area/liberty/hotel/hallway/staff)
 "aPz" = (
 /obj/machinery/light/spot,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/lino,
 /area/liberty/hotel/staff_room)
 "aPA" = (
@@ -40536,6 +40551,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberty/hallway/one/aft_terminal)
+"lYO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/turf/simulated/floor/lino,
+/area/liberty/hotel/staff_room)
 "mhQ" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -40635,6 +40658,12 @@
 	},
 /turf/space,
 /area/space)
+"qRL" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/liberty/hotel/staff_room)
 "rhr" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -40698,6 +40727,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/arrivals_shuttle)
+"uIf" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/hotel/staff_room)
 "vdt" = (
 /obj/effect/floor_decal/corner/black/full,
 /obj/effect/landmark/start{
@@ -40705,6 +40746,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/restaurant/main)
+"vxF" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 18
+	},
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/storage/box,
+/turf/simulated/floor/lino,
+/area/liberty/hotel/staff_room)
 "vFH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -55596,7 +55651,7 @@ aEr
 aFZ
 aHx
 aJa
-aKL
+aKM
 aMi
 aNJ
 aFZ
@@ -55999,7 +56054,7 @@ aDd
 aEu
 aFZ
 aHz
-aJb
+uIf
 aKN
 aMk
 aNL
@@ -56200,12 +56255,12 @@ aBN
 aDe
 aEv
 aFZ
-aHA
+vxF
 aHA
 aKO
 aMl
 aNM
-aFZ
+lYO
 aFZ
 aSn
 aTv
@@ -56402,11 +56457,11 @@ avu
 aDd
 aEr
 aFZ
-aHB
+aJd
 aJc
 aKP
 aJe
-aJe
+qRL
 aPz
 aFZ
 aSo
@@ -56605,11 +56660,11 @@ aDd
 aEw
 aFZ
 aHC
-aJd
+aJe
 aKQ
 aMm
 aNN
-aMm
+aKL
 aQX
 aSp
 aTx
@@ -56809,7 +56864,7 @@ aFZ
 aHD
 aJe
 aKR
-aJe
+aHB
 aNO
 aPA
 aFZ

--- a/maps/liberty/liberty3_level2.dmm
+++ b/maps/liberty/liberty3_level2.dmm
@@ -164,6 +164,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/bed/chair/wood/walnut{
+	dir = 8
+	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/library)
 "az" = (
@@ -741,6 +744,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_one)
 "bU" = (
@@ -865,6 +869,9 @@
 	},
 /obj/item/clothing/suit/storage/toggle/no_pockets/robe/bathrobe,
 /obj/item/towel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
 "ci" = (
@@ -921,6 +928,9 @@
 	},
 /obj/item/clothing/suit/storage/toggle/no_pockets/robe/bathrobe,
 /obj/item/towel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
 "cp" = (
@@ -990,6 +1000,9 @@
 /area/liberty/hotel/room/three_zero_three)
 "cw" = (
 /obj/structure/bed/chair/wood/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_one)
 "cx" = (
@@ -1005,6 +1018,9 @@
 	},
 /obj/item/clothing/suit/storage/toggle/no_pockets/robe/bathrobe,
 /obj/item/towel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
 "cz" = (
@@ -1076,6 +1092,9 @@
 "cG" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/material/ashtray/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_one)
 "cH" = (
@@ -1085,6 +1104,9 @@
 	},
 /obj/item/clothing/suit/storage/toggle/no_pockets/robe/bathrobe,
 /obj/item/towel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
 "cI" = (
@@ -1314,7 +1336,9 @@
 /area/liberty/hotel/room/three_zero_one)
 "dc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
 "dd" = (
@@ -1412,6 +1436,10 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
 "dm" = (
@@ -1444,9 +1472,6 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
-	},
-/obj/machinery/hotel_room_controller{
-	id_tag = "room_101_controller"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
@@ -1595,12 +1620,6 @@
 /area/liberty/hotel/room/one_zero_one)
 "dG" = (
 /obj/structure/undies_wardrobe/chestdrawer/walnut,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/button/alternate/door/bolts{
 	dir = 1;
 	id_tag = "room_101_airlock";
@@ -1612,6 +1631,14 @@
 	dir = 1;
 	pixel_x = -8;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/hotel_room_controller{
+	id_tag = "room_101_controller";
+	dir = 4;
+	pixel_x = 25
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
@@ -2155,6 +2182,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/hotel_room_controller{
+	id_tag = "room_201_controller";
+	dir = 8;
+	pixel_y = 4
+	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/two_zero_one)
 "eS" = (
@@ -2390,6 +2422,9 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/two_zero_one)
 "fo" = (
@@ -2426,6 +2461,9 @@
 "fq" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/material/ashtray/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_one)
 "fr" = (
@@ -3002,11 +3040,13 @@
 /area/liberty/hotel/restaurant/upper)
 "gp" = (
 /obj/structure/undies_wardrobe/chestdrawer/walnut,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/hotel_room_controller{
+	id_tag = "room_102_controller";
+	pixel_x = 25;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
@@ -3793,9 +3833,6 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
-	},
-/obj/machinery/hotel_room_controller{
-	id_tag = "room_104_controller"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
@@ -5521,6 +5558,10 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
 "kb" = (
@@ -5743,6 +5784,7 @@
 /area/liberty/hotel/room/three_zero_one)
 "kD" = (
 /obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_two)
 "kE" = (
@@ -5979,8 +6021,10 @@
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/two/fore)
 "lf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
 "lg" = (
@@ -6046,10 +6090,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
 "lo" = (
@@ -6109,8 +6153,10 @@
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/two/fore)
 "lt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
 "lu" = (
@@ -6610,6 +6656,7 @@
 /area/liberty/maintenance/two/fore)
 "mA" = (
 /obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_three)
 "mB" = (
@@ -6743,6 +6790,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_two)
 "mM" = (
@@ -6880,6 +6928,9 @@
 /area/liberty/maintenance/two)
 "mZ" = (
 /obj/structure/undies_wardrobe/chestdrawer/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_one)
 "na" = (
@@ -7480,7 +7531,9 @@
 /area/liberty/maintenance/two)
 "or" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
 "os" = (
@@ -8004,6 +8057,9 @@
 /area/liberty/maintenance/two)
 "pA" = (
 /obj/structure/bed/chair/wood/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_three)
 "pB" = (
@@ -8065,12 +8121,10 @@
 /turf/simulated/floor/tiled/white,
 /area/liberty/medbay/storage)
 "pH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_one)
 "pI" = (
@@ -8089,6 +8143,9 @@
 	},
 /obj/machinery/light/spot{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/two_zero_two)
@@ -8375,10 +8432,10 @@
 	pixel_x = 33;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
 "qs" = (
@@ -8497,12 +8554,10 @@
 /turf/simulated/floor/plating,
 /area/liberty/engineering/substation/substation_level_two)
 "qD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_three)
 "qE" = (
@@ -8928,12 +8983,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_three)
 "ru" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_one)
 "rv" = (
@@ -9085,7 +9138,9 @@
 /area/liberty/hotel/over_stage)
 "rN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
 "rO" = (
@@ -9286,6 +9341,10 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
@@ -9548,6 +9607,9 @@
 "sK" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/material/ashtray/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_two)
 "sL" = (
@@ -9829,6 +9891,9 @@
 /area/liberty/hotel/dorm)
 "tl" = (
 /obj/structure/undies_wardrobe/chestdrawer/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_two)
 "tm" = (
@@ -10005,10 +10070,10 @@
 	pixel_x = 33;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
 "tG" = (
@@ -10041,12 +10106,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberty/library)
 "tJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_two)
 "tK" = (
@@ -10647,9 +10710,6 @@
 /obj/machinery/light/spot,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/machinery/hotel_room_controller{
-	id_tag = "room_202_controller"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/two_zero_two)
@@ -11282,14 +11342,22 @@
 /area/liberty/hotel/restaurant/upper)
 "wu" = (
 /obj/structure/undies_wardrobe/chestdrawer/walnut,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/hotel_room_controller{
+	id_tag = "room_103_controller";
+	pixel_x = 25;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
+"wv" = (
+/obj/structure/bed/chair/bench/wood/walnut/left{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/liberty/library)
 "ww" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -11795,12 +11863,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberty/maintenance/two/starboard)
 "xY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_two)
 "xZ" = (
@@ -12582,6 +12648,7 @@
 /area/liberty/hallway/two)
 "zC" = (
 /obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_one)
 "zD" = (
@@ -12767,14 +12834,13 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/obj/machinery/hotel_room_controller{
-	id_tag = "room_103_controller"
-	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
 "Ab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
 "Ac" = (
@@ -12947,16 +13013,21 @@
 /area/liberty/hotel/room/two_zero_two)
 "AB" = (
 /obj/structure/undies_wardrobe/chestdrawer/walnut,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/hotel_room_controller{
+	id_tag = "room_104_controller";
+	dir = 4;
+	pixel_x = 25
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_four)
 "AC" = (
 /obj/structure/bed/chair/wood/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_two)
 "AD" = (
@@ -13343,6 +13414,7 @@
 /area/liberty/maintenance/two/port)
 "BF" = (
 /obj/structure/bed/chair/wood/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_one)
 "BI" = (
@@ -13941,14 +14013,15 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_one)
 "Dq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_one)
@@ -14039,6 +14112,11 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/machinery/hotel_room_controller{
+	id_tag = "room_202_controller";
+	dir = 8;
+	pixel_y = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/two_zero_two)
@@ -15247,6 +15325,13 @@
 /obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_one)
+"GF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/liberty/hotel/room/two_zero_one)
 "GG" = (
 /obj/effect/floor_decal/corner/black/half,
 /obj/effect/floor_decal/corner/black/half,
@@ -15313,9 +15398,6 @@
 /obj/machinery/light/spot,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/machinery/hotel_room_controller{
-	id_tag = "room_201_controller"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/two_zero_one)
@@ -15859,10 +15941,10 @@
 	pixel_x = 33;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
 "Ie" = (
@@ -16104,7 +16186,9 @@
 	dir = 1
 	},
 /obj/machinery/hotel_room_controller{
-	id_tag = "room_303_controller"
+	id_tag = "room_303_controller";
+	dir = 1;
+	pixel_y = 2
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_three)
@@ -16229,6 +16313,9 @@
 /area/liberty/medbay/hallway/two)
 "IZ" = (
 /obj/structure/bed/sofa/black/left,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_two)
 "Jb" = (
@@ -16497,6 +16584,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_three)
 "JE" = (
@@ -16713,6 +16801,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/two)
+"Kf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/liberty/hotel/room/two_zero_two)
 "Kg" = (
 /obj/effect/floor_decal/corner/grey/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -17333,7 +17428,9 @@
 	dir = 1
 	},
 /obj/machinery/hotel_room_controller{
-	id_tag = "room_301_controller"
+	id_tag = "room_301_controller";
+	dir = 1;
+	pixel_y = 2
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_one)
@@ -17669,6 +17766,9 @@
 /area/liberty/maintenance/two/port)
 "Mz" = (
 /obj/structure/bed/sofa/black/left,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_one)
 "MA" = (
@@ -17916,8 +18016,10 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberty/hotel/room/three_zero_three)
 "Nh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
 "Ni" = (
@@ -18785,6 +18887,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_three)
 "Po" = (
@@ -19294,6 +19397,9 @@
 "QD" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/material/ashtray/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_three)
 "QE" = (
@@ -19403,8 +19509,10 @@
 /turf/simulated/floor/carpet/red,
 /area/liberty/chapel/office)
 "QM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_one)
 "QO" = (
@@ -19442,6 +19550,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/room/one_zero_one)
+"QU" = (
+/obj/structure/bed/chair/bench/wood/walnut/right{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/liberty/library)
 "QV" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -19942,7 +20056,9 @@
 	dir = 1
 	},
 /obj/machinery/hotel_room_controller{
-	id_tag = "room_302_controller"
+	id_tag = "room_302_controller";
+	dir = 1;
+	pixel_y = 2
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_two)
@@ -20323,12 +20439,10 @@
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/two/port)
 "SV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_three)
 "SW" = (
@@ -20967,6 +21081,7 @@
 /area/liberty/scg/representative)
 "Uq" = (
 /obj/structure/bed/chair/wood/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_two)
 "Us" = (
@@ -21616,6 +21731,10 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_three)
 "VS" = (
@@ -21969,9 +22088,6 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/obj/machinery/hotel_room_controller{
-	id_tag = "room_102_controller"
-	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/one_zero_two)
 "WN" = (
@@ -22047,8 +22163,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/two_zero_two)
@@ -22259,6 +22375,9 @@
 "XA" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/material/ashtray/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/hotel/room/three_zero_two)
 "XB" = (
@@ -22503,6 +22622,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/room/three_zero_two)
 "Yi" = (
@@ -33511,7 +33631,7 @@ IO
 eJ
 WJ
 fd
-IM
+GF
 IM
 Dq
 BF
@@ -34723,7 +34843,7 @@ Rd
 Vv
 Bh
 Rx
-DI
+Kf
 DI
 WV
 Uq
@@ -36102,8 +36222,8 @@ ag
 ag
 Aq
 at
-QP
-QP
+wv
+QU
 QP
 QP
 NV

--- a/maps/liberty/liberty4_level3.dmm
+++ b/maps/liberty/liberty4_level3.dmm
@@ -1615,6 +1615,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/space)
+"eH" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
 "eJ" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
@@ -1884,6 +1896,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/three/fore)
+"fO" = (
+/obj/effect/floor_decal/corner/grey/mono,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/liberty/hallway/three)
 "fP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5025,6 +5050,21 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/three/starboard)
+"us" = (
+/obj/effect/floor_decal/corner/grey/mono,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/liberty/hallway/three)
 "uu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6803,6 +6843,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/three/port)
+"BL" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
 "BO" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/device/flashlight/lamp/modern{
@@ -9935,6 +9982,18 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/liberty/director/office)
+"OH" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
 "OJ" = (
 /obj/effect/floor_decal/spline/fancy/black/corner{
 	dir = 1
@@ -10048,6 +10107,16 @@
 "Pp" = (
 /obj/structure/flora/jungle/bush/a_2,
 /turf/simulated/floor/grass,
+/area/liberty/hallway/three)
+"Pq" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/three)
 "Ps" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10617,6 +10686,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/command)
+"RH" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
 "RI" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/machinery/photocopier,
@@ -10632,6 +10713,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/three)
 "RK" = (
@@ -12396,6 +12478,19 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
+"Zs" = (
+/obj/effect/floor_decal/corner/grey/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/liberty/hallway/three)
 "Zu" = (
 /obj/machinery/hologram/holopad,
@@ -23547,9 +23642,9 @@ Mh
 IJ
 LB
 ac
-BW
-aN
-Ew
+BL
+Zs
+ZV
 lk
 lk
 kw
@@ -24557,9 +24652,9 @@ aa
 aa
 SK
 fY
-BW
-aN
-Ew
+BL
+Zs
+ZV
 lk
 fJ
 RZ
@@ -25371,7 +25466,7 @@ IC
 Um
 IC
 IC
-IC
+fO
 IC
 IC
 CG
@@ -26181,9 +26276,9 @@ NS
 nR
 NS
 eu
-BW
-oW
-Ew
+BL
+Zs
+ZV
 lk
 lk
 lk
@@ -27999,9 +28094,9 @@ Xv
 QJ
 NS
 UK
-BW
-oW
-NA
+BL
+Zs
+Pq
 lk
 Wb
 St
@@ -28600,7 +28695,7 @@ dq
 IB
 ah
 lO
-Ur
+eH
 tw
 yh
 Ur
@@ -28802,7 +28897,7 @@ dy
 dv
 XX
 jO
-cu
+us
 cu
 cu
 cu
@@ -29004,7 +29099,7 @@ dk
 ly
 ah
 hu
-te
+OH
 dU
 pB
 te
@@ -29616,8 +29711,8 @@ dX
 yt
 NU
 RJ
-ZC
-Ew
+Zs
+ZV
 lk
 sE
 Ol
@@ -31636,8 +31731,8 @@ iL
 Cl
 NU
 RJ
-ZC
-wn
+Zs
+RH
 gq
 FX
 dw


### PR DESCRIPTION
Something went wrong last time...

- Now hotel room terminals have dir's to more fit into variable environment.

- Doubled the amount of vents and scrubbers in room.

- Backroom behind registry remapped into storage room.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->