### PR TITLE
Map update

### DIFF
--- a/maps/liberty/liberty2_level1.dmm
+++ b/maps/liberty/liberty2_level1.dmm
@@ -4614,6 +4614,9 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 1
 	},
+/obj/machinery/atm{
+	pixel_x = -27
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/one/fore_terminal)
 "aiL" = (
@@ -5757,6 +5760,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/atm{
+	pixel_x = 27
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/one/fore_terminal)
@@ -14382,6 +14388,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/one/fore_port)
 "aBW" = (
@@ -17193,12 +17202,11 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
+	},
+/obj/machinery/atm{
+	pixel_x = 27
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/one)
@@ -17875,6 +17883,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/shopping/keeper)
 "aHL" = (
@@ -18635,6 +18644,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
 "aJq" = (
@@ -19603,6 +19616,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
 "aKY" = (
@@ -19623,6 +19640,7 @@
 	dir = 8;
 	pixel_x = -4
 	},
+/obj/machinery/door/window/brigdoor/southright,
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
 "aLa" = (
@@ -22264,6 +22282,10 @@
 /obj/structure/window/reinforced{
 	pixel_y = -3
 	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
 "aPL" = (
@@ -22292,6 +22314,10 @@
 	},
 /obj/structure/window/reinforced{
 	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
@@ -23046,6 +23072,10 @@
 /obj/effect/floor_decal/spline/plain/red{
 	dir = 10
 	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
 "aRg" = (
@@ -23694,6 +23724,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/device/eftpos,
+/obj/item/device/eftpos,
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/foyer)
 "aSr" = (
@@ -23728,6 +23760,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
+	},
+/obj/machinery/atm{
+	pixel_x = 27
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/one/aft_port)
@@ -23783,6 +23818,10 @@
 /obj/structure/window/reinforced{
 	dir = 8;
 	pixel_x = -4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/shopping)
@@ -23860,6 +23899,7 @@
 	},
 /obj/effect/floor_decal/corner/purple/mono,
 /obj/item/hand_labeler,
+/obj/item/device/eftpos,
 /turf/simulated/floor/tiled/white/monotile,
 /area/liberty/rnd)
 "aSJ" = (
@@ -24343,6 +24383,10 @@
 "aTy" = (
 /obj/machinery/computer/modular/preset/hotel{
 	dir = 8
+	},
+/obj/item/paper{
+	name = "Персоналу отеля!";
+	info = "Системы отеля окончательно вышли из строя с момента последней магнитной бури.<BR> Мы откатились до базовой версии, так что я рассчитываю на то, что вы будете вручную вести дела!"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberty/hotel/foyer)
@@ -25078,6 +25122,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/machinery/atm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/one/aft_port)
 "aUR" = (
@@ -28334,6 +28381,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/cargo_bay/one/office)
 "baL" = (
@@ -29035,6 +29083,7 @@
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/item/device/eftpos,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/cargo_bay/one/office)
 "bca" = (
@@ -29203,6 +29252,7 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/wood/maple,
 /area/liberty/medbay/chemistry)
 "bcq" = (
@@ -30210,6 +30260,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/wood/maple,
 /area/liberty/medbay/exam)
 "bdT" = (
@@ -32732,6 +32783,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hotel/restaurant/main)
 "bhS" = (
@@ -40392,6 +40444,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberty/arrivals_shuttle)
+"bLO" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/one)
 "cvK" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -40494,6 +40556,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/liberty/maintenance/one/aft_starboard)
+"ilm" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/one/starboard)
 "iDw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -40570,6 +40641,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberty/hallway/one/aft_terminal)
+"lGI" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/one/fore_port)
 "lYO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -40708,6 +40788,15 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"sEm" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled/white,
+/area/liberty/shopping)
 "sKX" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock,
@@ -40754,6 +40843,21 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"sZP" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/spline/plain/red{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/liberty/shopping)
 "ucr" = (
 /obj/machinery/cryopod,
 /obj/machinery/light,
@@ -54667,7 +54771,7 @@ aeO
 agr
 azb
 aAy
-avu
+lGI
 aCY
 aEo
 aFV
@@ -60131,7 +60235,7 @@ aKZ
 aHP
 aNY
 aPM
-aKZ
+sZP
 aHP
 aTD
 aUP
@@ -60328,8 +60432,8 @@ aDi
 aEE
 aGg
 aHR
-aJs
-aJs
+sEm
+sEm
 aJs
 aOa
 aJs
@@ -63163,7 +63267,7 @@ aOj
 aGk
 aJz
 aHX
-aJz
+bLO
 aCb
 aDl
 aGk
@@ -66194,7 +66298,7 @@ aQd
 aRs
 aSO
 aSQ
-aUY
+ilm
 aWm
 aXn
 aYJ

--- a/maps/liberty/liberty3_level2.dmm
+++ b/maps/liberty/liberty3_level2.dmm
@@ -11153,6 +11153,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/liberty/rnd/toxins)
+"vT" = (
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood/walnut,
+/area/liberty/hotel/hallway/east)
 "vU" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/spline/fancy{
@@ -12595,6 +12604,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
+/obj/item/device/eftpos,
 /turf/simulated/floor/carpet/blue2,
 /area/liberty/scg/representative)
 "zr" = (
@@ -13565,6 +13575,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/two)
 "BS" = (
@@ -14012,6 +14025,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
+/area/liberty/hallway/two)
+"Dg" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/atm{
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/two)
 "Dh" = (
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -15753,6 +15775,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/two/fore)
@@ -20827,6 +20852,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/wood/walnut,
 /area/liberty/corporate_office)
 "Tw" = (
@@ -23121,6 +23147,7 @@
 /obj/item/device/flashlight/lamp/modern{
 	pixel_y = 5
 	},
+/obj/item/device/eftpos,
 /turf/simulated/floor/wood/walnut,
 /area/liberty/private_eye)
 "Zo" = (
@@ -23334,6 +23361,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/two/fore)
 
@@ -38592,7 +38622,7 @@ kY
 oa
 oa
 oa
-Er
+vT
 QK
 IE
 IE
@@ -45681,7 +45711,7 @@ YL
 Sl
 YL
 Xr
-YL
+Dg
 HT
 lu
 tg

--- a/maps/liberty/liberty4_level3.dmm
+++ b/maps/liberty/liberty4_level3.dmm
@@ -2556,6 +2556,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/three)
+"jl" = (
+/obj/effect/floor_decal/carpet/blue{
+	dir = 1
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/paper{
+	name = "Нашему коллеге!";
+	info = "Эффективность вашего сектора упала за последние несколько месяцев, директор.<BR> Мы надеемся на то, что ваши менеджерские таланты помогут исправить текущее положение дел."
+	},
+/turf/simulated/floor/carpet/blue,
+/area/liberty/director/office)
 "jm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -5526,6 +5537,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_x = 27
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/hallway/three)
@@ -9422,6 +9436,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/liberty/hotel/room/penthouse/bathroom)
+"LO" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/machinery/atm{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
 "LR" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -2;
@@ -9595,6 +9618,7 @@
 	dir = 1
 	},
 /obj/structure/table/woodentable/walnut,
+/obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/carpet/blue,
 /area/liberty/director/office)
 "MB" = (
@@ -10487,6 +10511,15 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberty/maintenance/three/fore)
+"Qq" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/machinery/atm{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three/starboard)
 "Qs" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11967,6 +12000,22 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberty/maintenance/three/port)
+"Wr" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/obj/machinery/atm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/liberty/hallway/three)
 "Wt" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -25365,7 +25414,7 @@ IY
 AT
 Ur
 vl
-vl
+LO
 vl
 QA
 PH
@@ -35466,7 +35515,7 @@ ac
 ac
 Py
 eW
-Rs
+Wr
 oW
 LL
 AT
@@ -35477,7 +35526,7 @@ IY
 AT
 Bb
 XP
-vl
+LO
 Ur
 cK
 pl
@@ -37284,7 +37333,7 @@ hb
 SK
 SK
 Ti
-Mu
+jl
 aH
 ak
 ch
@@ -38504,7 +38553,7 @@ YT
 aQ
 ky
 uq
-nM
+Qq
 Ht
 wG
 oj

--- a/maps/liberty/ship_lucius/lucius1_deck2.dmm
+++ b/maps/liberty/ship_lucius/lucius1_deck2.dmm
@@ -2351,6 +2351,11 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/table/steel,
+/obj/item/paper{
+	name = "Прочесть перед работой с камерой сгорания!";
+	info = "Не забудь докачать диоксид углерода! Он в канистре, которая находится в шлюзе между этим помещением и двигателями!"
+	},
 /turf/simulated/floor/plating,
 /area/lucius/fuel)
 "gB" = (
@@ -3397,6 +3402,7 @@
 /area/lucius/storage)
 "jy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/lucius/storage)
 "jz" = (
@@ -3877,6 +3883,7 @@
 /area/lucius/hangar)
 "pS" = (
 /obj/item/stack/tile/floor,
+/obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating,
 /area/lucius/storage)
 "pU" = (
@@ -5632,6 +5639,9 @@
 "UM" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/phoron{
+	amount = 10
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/lucius/storage)
 "UU" = (

--- a/maps/liberty/ship_venturestar/venturestar.dmm
+++ b/maps/liberty/ship_venturestar/venturestar.dmm
@@ -2312,13 +2312,15 @@
 /area/venturestar/engineering)
 "eA" = (
 /obj/structure/catwalk,
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/alarm/venturestar{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
+	},
+/obj/machinery/suit_storage_unit/mining/alt{
+	req_access = list("ACCESS_VENTURESTAR")
 	},
 /turf/simulated/floor,
 /area/venturestar/engineering)


### PR DESCRIPTION
- changed one standard spacesuit station to a mining one in Venture Star

- Add ETPOS scaneers to all service and trading places

- added oxygen canister and pacman to the warehouse on Lucius

- added ATM's in public places on Liberty

-

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->